### PR TITLE
RPLidar UART/I2C Arduino Due/Uno programs

### DIFF
--- a/RPLidar/readme.txt
+++ b/RPLidar/readme.txt
@@ -1,0 +1,6 @@
+Test programs should send a "hello" string in the form of bytes from Arduino Uno slave to Arduino Due master (i2c).
+
+Due Master writer and Uno slave reader is not sending proper data for some reason (yet), only sends zeroes. Will look into it.
+Connection is functional however as shown by the test programs.
+
+- Kyle Lam (3/5/2016)

--- a/RPLidar/rplidar_due_master.ino
+++ b/RPLidar/rplidar_due_master.ino
@@ -1,0 +1,83 @@
+// RPLIDAR Arduino Due master reader program
+// File name: rplidar_due_master.ino
+// Author: Kyle Lam
+// Date: 2/27/16
+// Revision: 1.1
+// MASTER READER for DUE
+
+#include <Wire.h>
+
+// vars
+byte allData[8];
+float distance;
+float angle;
+bool  startBit;
+byte  quality;
+
+void setup() {
+  Wire.begin();
+  Serial.begin(115200);  // start serial for output
+}
+
+void loop() {
+  Wire.beginTransmission(8);
+  Wire.requestFrom(8, 8);    // request 10 bytes from slave device #8
+
+  // receive all sent data
+  if (Wire.available()) {
+    int i = 0;
+    while (Wire.available()) {
+      allData[i] = Wire.read();
+      i++;
+    }
+  }
+
+  // store data
+  dataToFloat(allData, distance, angle);
+//  quality = allData[10];
+
+  Wire.endTransmission();
+
+  Serial.println(distance);
+  Serial.println(angle);
+
+  delay(500);
+}
+
+// function for converting distance/angle bytes to float
+void dataToFloat (byte* data, float distance, float angle) {
+  // get distance bytes into union
+  union distanceData {
+    byte distanceBytes[4];
+    float distanceValue;
+  } dData;
+  dData.distanceBytes[0] = data[0];
+  dData.distanceBytes[1] = data[1];
+  dData.distanceBytes[2] = data[2];
+  dData.distanceBytes[3] = data[3];
+  // set distance
+  distance = dData.distanceValue;
+
+  // get angle bytes into union
+  union angleData {
+    byte angleBytes[4];
+    float angleValue;
+  } aData;
+  aData.angleBytes[0] = data[4];
+  aData.angleBytes[1] = data[5];
+  aData.angleBytes[2] = data[6];
+  aData.angleBytes[3] = data[7];
+  // set angle
+  angle = aData.angleValue;
+
+//  // get start bytes into union
+//  union startData {
+//    byte startBytes[2];
+//    bool startValue;
+//  } sData;
+//  sData.startBytes[0] = data[8];
+//  sData.startBytes[1] = data[9];
+//  // set start
+//  startBit = sData.startValue;
+}
+

--- a/RPLidar/rplidar_due_master_TEST.ino
+++ b/RPLidar/rplidar_due_master_TEST.ino
@@ -1,0 +1,24 @@
+// RPLIDAR Arduino Due master reader program TEST
+// File name: rplidar_due_master.ino
+// Author: Kyle Lam
+// Date: 2/27/16
+// Revision: 1.0
+// MASTER READER for DUE
+
+#include <Wire.h>
+
+void setup() {
+  Wire.begin();        // join i2c bus (address optional for master)
+  Serial.begin(115200);  // start serial for output
+}
+
+void loop() {
+  Wire.requestFrom(8, 6);    // request 6 bytes from slave device #8
+
+  while (Wire.available()) { // slave may send less than requested
+    char c = Wire.read(); // receive a byte as character
+    Serial.print(c);         // print the character
+  }
+
+  delay(500);
+}

--- a/RPLidar/rplidar_due_slave.ino
+++ b/RPLidar/rplidar_due_slave.ino
@@ -1,0 +1,74 @@
+#include <Wire.h>
+
+void setup() {
+  // begin I2C
+  Wire.begin(8);
+  Wire.onReceive(receiveEvent);
+
+  // begin Serial (for serial monitor display)
+  Serial.begin(115200);
+
+}
+
+void loop() {
+  delay(100);
+
+}
+
+// function that executes whenever data is received from master
+void receiveEvent(int howMany) {
+
+  // for storing floats
+  float distance;
+  float angle;
+  bool  startBit;
+  byte  quality;
+  
+  // for receiving bytes
+  byte allData[10];
+
+  // receive all sent data
+  if (Wire.available()) {
+    int i = 0;
+    while (Wire.available()) {
+      allData[i] = Wire.read();
+      i++;
+    }
+  }
+
+  // store data
+  dataToFloat(allData, distance, angle);
+  startBit = allData[8];
+  quality = allData[9];
+
+  Serial.println(distance);
+  Serial.println(angle);
+}
+
+// function for converting distance/angle bytes to float
+void dataToFloat (byte* data, float distance, float angle) {
+  // get distance bytes into union
+  union distanceData {
+    byte distanceBytes[4];
+    float distanceValue;
+  } dData;
+  dData.distanceBytes[0] = data[0];
+  dData.distanceBytes[1] = data[1];
+  dData.distanceBytes[2] = data[2];
+  dData.distanceBytes[3] = data[3];
+  // set distance
+  distance = dData.distanceValue;
+
+  // get angle bytes into union
+  union angleData {
+    byte angleBytes[4];
+    float angleValue;
+  } aData;
+  aData.angleBytes[0] = data[4];
+  aData.angleBytes[1] = data[5];
+  aData.angleBytes[2] = data[6];
+  aData.angleBytes[3] = data[7];
+  // set angle
+  angle = aData.angleValue;
+}
+

--- a/RPLidar/rplidar_uno_master.ino
+++ b/RPLidar/rplidar_uno_master.ino
@@ -1,0 +1,73 @@
+// This sketch code is based on the RPLIDAR driver library provided by RoboPeak
+#include <RPLidar.h>
+#include <Wire.h>
+
+// You need to create an driver instance 
+RPLidar lidar;
+
+#define RPLIDAR_MOTOR 3 // The PWM pin for control the speed of RPLIDAR's motor.
+                        // This pin should connected with the RPLIDAR's MOTOCTRL signal 
+                       
+                        
+void setup() {
+  // bind the RPLIDAR driver to the arduino hardware serial
+  lidar.begin(Serial);
+
+  // begin I2C (master)
+  Wire.begin();
+  
+  // set pin modes
+  pinMode(RPLIDAR_MOTOR, OUTPUT);
+}
+
+void loop() {
+  if (IS_OK(lidar.waitPoint())) {
+    float distance = lidar.getCurrentPoint().distance; //distance value in mm unit
+    float angle    = lidar.getCurrentPoint().angle; //anglue value in degree
+    bool  startBit = lidar.getCurrentPoint().startBit; //whether this point is belong to a new scan
+    byte  quality  = lidar.getCurrentPoint().quality; //quality of the current measurement
+
+    // convert to bytes
+    byte distanceBytes[4];
+    byte angleBytes[4];
+    floatToByte(distance, distanceBytes);
+    floatToByte(angle, angleBytes);
+
+    // transmission I2C
+    Wire.beginTransmission(8);
+    Wire.write(distanceBytes, 4);
+    Wire.write(angleBytes, 4);
+    Wire.write(startBit);
+    Wire.write(quality);
+    Wire.endTransmission();
+    
+  } else {
+    analogWrite(RPLIDAR_MOTOR, 0); //stop the rplidar motor
+    
+    // try to detect RPLIDAR... 
+    rplidar_response_device_info_t info;
+    if (IS_OK(lidar.getDeviceInfo(info, 100))) {
+       // detected...
+       lidar.startScan();
+       
+       // start motor rotating at max allowed speed
+       analogWrite(RPLIDAR_MOTOR, 255);
+       delay(1000);
+    }
+  }
+}
+
+// for float to byte conversion (I2C communication sends bytes)
+void floatToByte(float value, byte* byteArray) {
+  // create union for copying byte array
+  union {
+    float floatVar;
+    byte tempArray[4];
+  } u;
+  // overwrite bytes in union with float
+  u.floatVar = value;
+
+  // assign bytes to input byte array
+  memcpy(byteArray, u.tempArray, 4);
+}
+

--- a/RPLidar/rplidar_uno_slave.ino
+++ b/RPLidar/rplidar_uno_slave.ino
@@ -1,0 +1,102 @@
+// RPLIDAR Arduino Uno slave writer program
+// File name: rplidar_uno_slave.ino
+// Author: Kyle Lam
+// Date: 2/27/16
+// Revision: 1.1
+// SLAVE WRITER for UNO
+
+#include <RPLidar.h>
+#include <Wire.h>
+
+RPLidar lidar;
+
+#define RPLIDAR_MOTOR 3 // The PWM pin for control the speed of RPLIDAR's motor.
+                        // This pin should connected with the RPLIDAR's MOTOCTRL signal
+                        
+volatile byte* distanceBytes;
+volatile byte* angleBytes;
+volatile byte* startBytes;
+
+float distance;
+float angle;
+bool startBit;
+byte quality;
+
+void setup() {
+  // bind the RPLIDAR driver to the arduino hardware serial
+  lidar.begin(Serial);
+
+  // initialize i2c, listen for write request
+  Wire.begin(8);
+  Wire.onRequest(requestEvent);
+
+  // set pin modes
+  pinMode(RPLIDAR_MOTOR, OUTPUT);
+}
+
+void loop() {
+  if (IS_OK(lidar.waitPoint())) {
+    distance = lidar.getCurrentPoint().distance; //distance value in mm unit
+    angle    = lidar.getCurrentPoint().angle; //anglue value in degree
+    startBit = lidar.getCurrentPoint().startBit; //whether this point is belong to a new scan
+    quality  = lidar.getCurrentPoint().quality; //quality of the current measurement
+
+//    // convert to bytes
+//    byte distanceBytes[4];
+//    byte angleBytes[4];
+//    floatToByte(distance, distanceBytes);
+//    floatToByte(angle, angleBytes);
+    
+  } else {
+    analogWrite(RPLIDAR_MOTOR, 0); //stop the rplidar motor
+    
+    // try to detect RPLIDAR... 
+    rplidar_response_device_info_t info;
+    if (IS_OK(lidar.getDeviceInfo(info, 100))) {
+       // detected...
+       lidar.startScan();
+       
+       // start motor rotating at max allowed speed
+       analogWrite(RPLIDAR_MOTOR, 255);
+       delay(1000);
+    }
+  }
+}
+
+// function that executes whenever data is requested by master
+// this function is registered as an event, see setup()
+void requestEvent() {
+  byte* sendData;
+  
+  distanceBytes = (byte*) &distance;
+  angleBytes = (byte*) &angle;
+//  startBytes = (byte*) &startBit;
+  
+  sendData[0] = distanceBytes[0];
+  sendData[1] = distanceBytes[1];
+  sendData[2] = distanceBytes[2];
+  sendData[3] = distanceBytes[3];
+  sendData[4] = angleBytes[0];
+  sendData[5] = angleBytes[1];
+  sendData[6] = angleBytes[2];
+  sendData[7] = angleBytes[3];
+//  sendData[8] = startBytes[0];
+//  sendData[9] = startBytes[1];
+//  sendData[10] = quality;
+  
+  Wire.write(sendData, 8);
+}
+
+//// for float to byte conversion (I2C communication sends bytes)
+//void floatToByte(float value, byte* byteArray) {
+//  // create union for copying byte array
+//  union {
+//    float floatVar;
+//    byte tempArray[4];
+//  } u;
+//  // overwrite bytes in union with float
+//  u.floatVar = value;
+//
+//  // assign bytes to input byte array
+//  memcpy(byteArray, u.tempArray, 4);
+//}

--- a/RPLidar/rplidar_uno_slave_TEST.ino
+++ b/RPLidar/rplidar_uno_slave_TEST.ino
@@ -1,0 +1,24 @@
+// RPLIDAR Arduino Uno slave writer program TEST
+// File name: rplidar_uno_slave.ino
+// Author: Kyle Lam
+// Date: 2/27/16
+// Revision: 1.0
+// SLAVE WRITER for UNO
+
+#include <Wire.h>
+
+void setup() {
+  Wire.begin(8);                // join i2c bus with address #8
+  Wire.onRequest(requestEvent); // register event
+}
+
+void loop() {
+  delay(100);
+}
+
+// function that executes whenever data is requested by master
+// this function is registered as an event, see setup()
+void requestEvent() {
+  Wire.write("hello "); // respond with message of 6 bytes
+  // as expected by master
+}


### PR DESCRIPTION
Finished test programs properly send "hello" across I2C from slave writer Arduino Uno to master reader Arduino Due. The RPLidar data does not yet properly send across I2C in the non-test programs although connection works as shown by test programs (probably due to float-to-byte conversion issues). Will look into it.